### PR TITLE
Calculate the expected number of args for start from dependsOn

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function startComponent(ctx, component, id, next) {
     return ctx[depId];
   });
   debug('Resolving ' + dependencies.length + ' dependencies for component ' + id);
-  var argc = component.start.length;
+  var argc = depIds.length + 1;
   var args = dependencies.slice(0, argc - 1);
   args[argc - 1] = function (err, started) {
     if (err) return next(toComponentError(id, err));


### PR DESCRIPTION
This enables an electric component to have its list of dependencies specified when it is instantiated.

In such a case, the start function would likely be defined as `start(...args)`, or `start()` with a reference to `arguments` in the function body.  In such cases, `start.length` will be 0 and it won't be possible to infer which argument is the `next` function based on `start.length`.  It is also not possible to overwrite the `length` property of a function.

I think the `start` function's length should always be equal to `(dependsOn || []).length + 1`.

I have a use case for this change.  I am working on a `TaskManager` component that can be used to block the shutdown of the app until pending tasks are complete.  The component would be instantiated like this:
```javascript
rascalTaskManager: new ElectricTaskManager({
  dependsOn: ['rascal'],
  beforeShutdown: ({ rascal }) => rascal.broker.unsubscribeAll(),
});
```